### PR TITLE
changed substitution macro jail from private column to chroot column

### DIFF
--- a/templates/master.cf.SLES11.3.erb
+++ b/templates/master.cf.SLES11.3.erb
@@ -12,7 +12,7 @@
 <% if @smtp_listen == 'all' -%>
 smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 <% else -%>
-<%= @smtp_listen %>:smtp      inet  <%= @jail %>       -       n       -       -       smtpd
+<%= @smtp_listen %>:smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 <% end -%>
 #smtp      inet  n       -       n       -       -       smtpd
 #submission inet n      -       n       -       -       smtpd

--- a/templates/master.cf.SLES11.4.erb
+++ b/templates/master.cf.SLES11.4.erb
@@ -12,7 +12,7 @@
 <% if @smtp_listen == 'all' -%>
 smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 <% else -%>
-<%= @smtp_listen %>:smtp      inet  <%= @jail %>       -       n       -       -       smtpd
+<%= @smtp_listen %>:smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 <% end -%>
 #submission inet n      -       n       -       -       smtpd
 #       -o smtpd_etrn_restrictions=reject

--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -12,7 +12,7 @@
 <% elsif @smtp_listen == 'all' -%>
 smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 <% else -%>
-<%= @smtp_listen %>:smtp      inet  <%= @jail %>       -       n       -       -       smtpd
+<%= @smtp_listen %>:smtp      inet  n       -       <%= @jail %>       -       -       smtpd
 <% end -%>
 <% if @master_submission -%>
 <%= @master_submission %>


### PR DESCRIPTION
In three of your templates the <% jail %-> macro was in the private column, instead of the chroot column. 